### PR TITLE
Minimum should still be 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.3",
+		"php": ">=8.2",
 		"altis/core": "dev-master",
 		"altis/cms": "dev-master",
 		"altis/cloud": "dev-master",


### PR DESCRIPTION
In trying to default to 8.3 I inadvertently set the minimum version to 8.3
